### PR TITLE
Add Exceptions for tasks

### DIFF
--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -10,6 +10,8 @@ import java.util.function.Predicate;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.model.task.exceptions.DuplicateTaskException;
+import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 /**
  * A list of tasks that enforces uniqueness between its elements and does not allow nulls.
@@ -46,7 +48,7 @@ public class TaskList implements Iterable<Task> {
     public void add(Task toAdd) {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
-            //throw new DuplicateTaskException();
+            throw new DuplicateTaskException();
         }
         internalList.add(toAdd);
     }
@@ -59,7 +61,7 @@ public class TaskList implements Iterable<Task> {
     public void delete(Task toDelete) {
         requireNonNull(toDelete);
         if (!internalList.remove(toDelete)) {
-            //throw new TaskNotFoundException();
+            throw new TaskNotFoundException();
         }
     }
 
@@ -75,11 +77,11 @@ public class TaskList implements Iterable<Task> {
 
         int index = internalList.indexOf(toEdit);
         if (index == -1) {
-            //throw new TaskNotFoundException();
+            throw new TaskNotFoundException();
         }
 
         if (!toEdit.isSameTask(editedTask) && contains(editedTask)) {
-            //throw new DuplicateTaskException();
+            throw new DuplicateTaskException();
         }
 
         internalList.set(index, editedTask);
@@ -94,7 +96,7 @@ public class TaskList implements Iterable<Task> {
     public Task find(Task toFind) {
         requireNonNull(toFind);
         if (!contains(toFind)) {
-            //throw new TaskNotFoundException();
+            throw new TaskNotFoundException();
         }
         return internalList.get(internalList.indexOf(toFind));
     }
@@ -197,7 +199,7 @@ public class TaskList implements Iterable<Task> {
     public void setTasks(List<Task> tasks) {
         requireAllNonNull(tasks);
         if (!tasksAreUnique(tasks)) {
-            //throw new DuplicateTaskException();
+            throw new DuplicateTaskException();
         }
 
         internalList.setAll(tasks);

--- a/src/main/java/seedu/address/model/task/exceptions/DuplicateTaskException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/DuplicateTaskException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.task.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Tasks (Tasks are considered duplicates if they have the same
+ * fields).
+ */
+public class DuplicateTaskException extends RuntimeException {
+    public DuplicateTaskException() {
+        super("Operation would result in duplicate tasks");
+    }
+}

--- a/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.task.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified task.
+ */
+public class TaskNotFoundException extends RuntimeException {
+}


### PR DESCRIPTION
There are no exception handlers for processes that deal with tasks.

Adding task-specific exceptions helps to maintain the normal, desired flow of the program even when unexpected events occur, preventing unwanted outcomes.

Close #53 