### PR TITLE
Allow finding of tasks using keywords

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/FindTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTaskCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.task.TaskContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all tasks in address book that have names or descriptions that contain any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "findTask";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all tasks that have names or descriptions "
+            + "that contain any of the specified keywords (case-insensitive) "
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " fix button";
+
+    private final TaskContainsKeywordsPredicate predicate;
+
+    public FindTaskCommand(TaskContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTaskList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TASK_LISTED_OVERVIEW, model.getFilteredTaskList().size()));
+    }
+
+    @Override
+    public boolean equals (Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindTaskCommand // instanceof handles nulls
+                && predicate.equals(((FindTaskCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterTaskCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindTaskCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTaskCommand;
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case DeleteTaskCommand.COMMAND_WORD:
             return new DeleteTaskCommandParser().parse(arguments);
+
+        case FindTaskCommand.COMMAND_WORD:
+            return new FindTaskCommandParser().parse(arguments);
 
         case FilterTaskCommand.COMMAND_WORD:
             return new FilterTaskParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/FindTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTaskCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.task.TaskContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindTaskCommand object.
+ */
+public class FindTaskCommandParser implements Parser<FindTaskCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindTaskCommand
+     * and returns a FindTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindTaskCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTaskCommand.MESSAGE_USAGE));
+        }
+
+        String[] keywords = trimmedArgs.split("\\s+");
+
+        return new FindTaskCommand(new TaskContainsKeywordsPredicate(Arrays.asList(keywords)));
+    }
+}

--- a/src/main/java/seedu/address/model/task/TaskContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/TaskContainsKeywordsPredicate.java
@@ -1,0 +1,33 @@
+package seedu.address.model.task;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Task}'s {@code Name} or {@code Description} matches any of the keywords given.
+ */
+public class TaskContainsKeywordsPredicate implements Predicate<Task> {
+    private final List<String> keywords;
+
+    public TaskContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Task task) {
+        return keywords.stream().anyMatch(
+                keyword -> StringUtil.containsWordIgnoreCase(task.getName().toString(), keyword))
+                || keywords.stream().anyMatch(
+                        keyword -> StringUtil.containsWordIgnoreCase(task.getDescription().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TaskContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TaskContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/task/TaskDescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/TaskDescriptionContainsKeywordsPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.task;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Task}'s {@code Description} matches any of the keywords given.
+ */
+public class TaskDescriptionContainsKeywordsPredicate implements Predicate<Task> {
+    private final List<String> keywords;
+
+    public TaskDescriptionContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Task task) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getDescription().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TaskDescriptionContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TaskDescriptionContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/task/TaskNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/TaskNameContainsKeywordsPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.StringUtil;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Task}'s {@code Name} matches any of the keywords given.
  */
 public class TaskNameContainsKeywordsPredicate implements Predicate<Task> {
     private final List<String> keywords;


### PR DESCRIPTION
Users are currently only able to view, filter, and sort the list of tasks, without being able to look for a specific task.

Finding tasks using keywords will allow users to quickly identify the specific tasks that they are looking for.

Close #113 