### PR TITLE
Bugfix addTask feature

### DIFF
--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -304,10 +304,18 @@ public class Task {
                 .append(getCategory())
                 .append("; Deadline: ")
                 .append(getDeadline())
-                .append("; Assigned to: ")
-                .append(getPerson())
-                .append("; Status: ");
+                .append("; Assigned to: ");
 
+        if (person == null) {
+            builder.append("None");
+        } else {
+            builder.append(getPersonName())
+                    .append(" ( ")
+                    .append(getEmail())
+                    .append(" )");
+        }
+
+        builder.append("; Status: ");
         if (isDone) {
             builder.append("Done");
         } else {


### PR DESCRIPTION
Currently, if a Task is assigned to no one, the message displayed to the user reads: "Assigned to: null".

However, this should be abstracted from the user. Hence, instead of null, the new message displays: "Assigned to: None".

Close #138 